### PR TITLE
Refactor: Harden codebase and align to C++17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Add optimization flags
-set(CMAKE_CXX_FLAGS_RELEASE "-O3 -DNDEBUG -march=native --std=c++20")
+set(CMAKE_CXX_FLAGS_RELEASE "-O3 -DNDEBUG -march=native --std=c++17")
 
 # Find Google Test
 find_package(GTest REQUIRED)

--- a/mpmc_packet_queue.h
+++ b/mpmc_packet_queue.h
@@ -135,6 +135,8 @@ private:
         
         Slot() : packet(), seq(0) {}
         
+        static_assert(sizeof(Packet) + sizeof(std::atomic<size_t>) <= CACHE_LINE_SIZE, 
+                      "The combined size of Packet and std::atomic<size_t> must not exceed CACHE_LINE_SIZE.");
         // Prevent false sharing by padding
         char padding[CACHE_LINE_SIZE - sizeof(Packet) - sizeof(std::atomic<size_t>)];
     };

--- a/mpmc_packet_queue_test.cpp
+++ b/mpmc_packet_queue_test.cpp
@@ -1,4 +1,4 @@
-// g++ mpmc_packet_queue_test.cpp -lgtest -lgtest_main -std=c++20  -lpthread
+// g++ mpmc_packet_queue_test.cpp -lgtest -lgtest_main -std=c++17  -lpthread
 
 
 #include <gtest/gtest.h>
@@ -465,7 +465,6 @@ TEST_F(MPMC_PacketQueueTest, BatchOperationsMultiThreaded) {
 TEST_F(MPMC_PacketQueueTest, MemoryOrderingTest) {
     // Test for proper memory ordering under high contention
     constexpr size_t iterations = 1000;
-    // constexpr size_t num_threads = std::thread::hardware_concurrency(); // anand
     size_t num_threads = std::thread::hardware_concurrency();
     
     for (size_t iter = 0; iter < iterations; ++iter) {

--- a/my_span.h
+++ b/my_span.h
@@ -66,11 +66,10 @@ namespace my_std {
             : data_(ptr), size_(count) {
             if constexpr (Extent != dynamic_extent) {
                 if (count != Extent) {
-                    // This scenario would typically be a compile-time error for std::span
-                    // if the count is known at compile time and doesn't match the static extent.
-                    // For runtime count, it's a runtime error.
-                    // For simplicity, we assume correct usage or rely on static_asserts in callers
-                    // or other constructors that enforce static extent matching.
+                    // For std::span, if 'count' were a constexpr mismatch, it would be a compile error.
+                    // For a runtime 'count', this is a runtime violation.
+                    // Use assert to catch this in debug builds.
+                    assert(count == Extent && "Runtime count must match static Extent for my_std::span");
                 }
             }
         }


### PR DESCRIPTION
This commit introduces several improvements to enhance robustness, correctness, and consistency of your codebase:

1.  **Harmonized C++ Standard to C++17:**
    *   Updated `CMakeLists.txt` to consistently use C++17 for
        `CMAKE_CXX_STANDARD` and compiler flags (`--std=c++17`).
    *   Adjusted a build command comment in the test file to reflect C++17.
        This ensures the project adheres to a defined C++ standard,
        leveraging `my_span.h` for C++17 compatibility.

2.  **Added `static_assert` for Slot Padding:**
    *   In `mpmc_packet_queue.h`, a `static_assert` was added to the `Slot`
        struct. This compile-time check ensures that the combined size of
        `Packet` and `std::atomic<size_t>` does not exceed `CACHE_LINE_SIZE`,
        preventing potential array size miscalculation for `Slot::padding`
        that could lead to unexpected behavior or compilation failures.

3.  **Improved `my_span.h` Static-Extent Constructor:**
    *   The `span(pointer ptr, size_type count)` constructor in `my_span.h`
        was enhanced. An `assert` is now used to validate that the runtime
        `count` matches the `Extent` when the span is defined with a
        static extent. This helps catch incorrect usage during debugging.

4.  **Minor Test Code Cleanup:**
    *   Removed a redundant commented-out line in
        `mpmc_packet_queue_test.cpp` for clarity.

These changes contribute to a more stable and maintainable codebase.